### PR TITLE
AMI-1159 Use https or http depending on env var

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -15,6 +15,7 @@ fs.readFile('/etc/buildnumber', function(err, data) {
 		'app': process.env.APP || 'sidecar',
 		'ip-address': process.env.IP_ADDRESS || os.networkInterfaces().eth0[0].address,
 		'app-port': process.env.PORT || '5000',
+		'proto': process.env.PROTO || 'http',
 		'hostname': process.env.HOSTNAME || os.hostname(),
 		'metadata': {
 			'version': process.env.VERSION || '0.0.1',

--- a/lib/eureka-sidecar.js
+++ b/lib/eureka-sidecar.js
@@ -1,3 +1,5 @@
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+
 var Client = require('node-rest-client').Client;
 
 module.exports = {
@@ -11,7 +13,8 @@ module.exports = {
 			'timer': 5,
 			'retries': 5,
 			'retry_timeout': 5,
-			'eureka_version': 'v2'
+			'eureka_version': 'v2',
+			'proto': 'http'
 		};
 		for (var key in defaults) {
 			options[key] = options[key] || defaults[key];
@@ -102,8 +105,7 @@ module.exports = {
 			}
 		};
 
-		var url = 'http://localhost:' + this.options['app-port'] + '/health';
-
+		var url = this.options['proto'] + '://localhost:' + this.options['app-port'] + '/health';
 		var req = this.client.get(url, health_check_args, function(data, response) {
 			if (response.statusCode >= 300) {
 				console.error("Error");
@@ -115,6 +117,7 @@ module.exports = {
 		});
 		req.on('error', function(err) {
 			console.log("Something went wrong connecting to local microservice: " + err.code);
+			console.log(err);
 			callback(false);
 		});
 	},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eureka-sidecar",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Library and optional CLI for registering with a Eureka service discovery server",
   "main": "lib/eureka-sidecar.js",
   "bin": {
@@ -30,7 +30,9 @@
     "service",
     "discovery"
   ],
-  "author": "Matt Harris",
+  "author": {
+    "name": "Matt Harris"
+  },
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/SplunkStorm/eureka-sidecar/issues"


### PR DESCRIPTION
PLEASEREVIEW @declanshanaghy @cgaspardSplunk @ranandwala 

Add an environment variable config option to use either http or https (with default to http to preserve behavior on microservices not yet updated) for the health check.  The port/proto used for the health check is what is reported to eureka, which is what hydra uses for connections.