### PR TITLE
Ami 2067 eureka fail

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -19,18 +19,21 @@ fs.readFile('/etc/buildnumber', function(err, data) {
 
 	SplunkCloudDynamicConfig.get_user_data(function(err, userdata) {
 		process.env.CLOUD_STACK = process.env.CLOUD_STACK || userdata.CLOUD_STACK;
-		sidecar.initialize({
-			'cloud_stack': process.env.CLOUD_STACK,
-			'app': process.env.APP || 'sidecar',
-			'ip-address': process.env.IP_ADDRESS || os.networkInterfaces().eth0[0].address,
-			'app-port': process.env.PORT || '5000',
-			'proto': process.env.PROTO || 'http',
-			'hostname': process.env.HOSTNAME || os.hostname(),
-			'metadata': {
-				'version': process.env.VERSION || '0.0.1',
-				'build': buildNumber
-			}
-		});
+		// Timeout to prevent runaway restarts
+		setTimeout(function() {
+			sidecar.initialize({
+				'cloud_stack': process.env.CLOUD_STACK,
+				'app': process.env.APP || 'sidecar',
+				'ip-address': process.env.IP_ADDRESS || os.networkInterfaces().eth0[0].address,
+				'app-port': process.env.PORT || '5000',
+				'proto': process.env.PROTO || 'http',
+				'hostname': process.env.HOSTNAME || os.hostname(),
+				'metadata': {
+					'version': process.env.VERSION || '0.0.1',
+					'build': buildNumber
+				}
+			});
+		}, 5000);
 	});
 });
 

--- a/lib/eureka-sidecar.js
+++ b/lib/eureka-sidecar.js
@@ -150,16 +150,22 @@ module.exports = {
                     winston.info("Service is up", metadata);
                 }
             }.bind(this));
+        var abort = function(err) {
+            throw err;
+        };
+
         var errorHandler = function(req) {
             metadata.level = "CRITICAL";
             winston.error("socket error", metadata);
             req.abort();
+            abort('error reaching eureka server');
         };
         req.on('requestTimeout', errorHandler);
         req.on('responseTimeout', errorHandler);
         req.on('error', function(err) {
             metadata.level = "CRITICAL";
             winston.error(err.message, metadata);
+            abort(err);
         });
     },
 

--- a/lib/eureka-sidecar.js
+++ b/lib/eureka-sidecar.js
@@ -135,11 +135,17 @@ module.exports = {
             }
         };
 
+        var abort = function(err) {
+            winston.error(err.message, metadata);
+            throw err;
+        };
+
         var req = this.client.post(this.options['eureka_url'] + '/' +
             this.options['eureka_version'] + '/apps/' + this.options['app'],
             register_args, function (data, response) {
                 if (response.statusCode >= 300) {
                     winston.error(data, metadata);
+                    abort(new Error('eureka server returned response code ' + response.statusCode));
                 } else {
                     this.registered = true;
                     metadata = {
@@ -150,21 +156,17 @@ module.exports = {
                     winston.info("Service is up", metadata);
                 }
             }.bind(this));
-        var abort = function(err) {
-            throw err;
-        };
 
         var errorHandler = function(req) {
             metadata.level = "CRITICAL";
             winston.error("socket error", metadata);
             req.abort();
-            abort('error reaching eureka server');
+            abort(new Error('error reaching eureka server'));
         };
         req.on('requestTimeout', errorHandler);
         req.on('responseTimeout', errorHandler);
         req.on('error', function(err) {
             metadata.level = "CRITICAL";
-            winston.error(err.message, metadata);
             abort(err);
         });
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eureka-sidecar",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Library and optional CLI for registering with a Eureka service discovery server",
   "main": "lib/eureka-sidecar.js",
   "bin": {

--- a/test/eureka-sidecar.js
+++ b/test/eureka-sidecar.js
@@ -159,7 +159,7 @@ describe('register', function () {
 describe('make_register_rest_call', function () {
     var client_postStub;
     var successResponse = {statusCode: 200};
-    var failResponse = {statusCode: 403};
+    var failResponse = {statusCode: 503};
     var client_postStub_return;
     var winston_errorStub;
     var reqStub = {abort: function() {}};
@@ -186,12 +186,12 @@ describe('make_register_rest_call', function () {
         sidecar.registered.should.be.true;
     });
 
-    it('does not throw an error on unsuccessful post', function () {
+    it('throws an error on unsuccessful post', function () {
         client_postStub.callsArgWith(2, 'error', failResponse);
         client_postStub.returns(client_postStub_return);
         (function () {
             sidecar.make_register_rest_call();
-        }).should.not.throw();
+        }).should.throw();
         client_postStub.called.should.be.true;
     });
 

--- a/test/eureka-sidecar.js
+++ b/test/eureka-sidecar.js
@@ -195,13 +195,20 @@ describe('make_register_rest_call', function () {
         client_postStub.called.should.be.true;
     });
 
-    it ('logs an error on timeouts', function() {
+    it ('logs an error and aborts on timeouts', function() {
         client_postStub.returns(client_postStub_return);
         client_postStub_return.on.onCall(0).callsArgWith(1, reqStub);
-        client_postStub_return.on.onCall(1).callsArgWith(1, reqStub);
+        (function() {
+            sidecar.make_register_rest_call();
+        }).should.throw();
+    });
+
+    it ('logs an error and aborts on socket errors', function() {
+        client_postStub.returns(client_postStub_return);
         client_postStub_return.on.onCall(2).callsArgWith(1, {message: 'error'});
-        sidecar.make_register_rest_call();
-        winston_errorStub.calledThrice.should.be.true;
+        (function() {
+            sidecar.make_register_rest_call();
+        }).should.throw();
     });
 });
 


### PR DESCRIPTION
PLEASEREVIEW @declanshanaghy @instantlinux @cloudbuilder 

Change eureka sidecar so that it will abnormally exit if it cannot register with the eureka server.  This
only affects initial registration.  Supervisor will by default restart a service that has abnormally exited, so 
no changes to each microservice are needed to deploy this fix; just build a foundation AMI with this version of sidecar and build each new microservice off that foundation.

Also added a 5 sec delay on startup.  Supervisor considers a service that starts and fails too quickly to be flawed and will eventually stop respawning it.  By adding the delay to the beginning, any abnormal exit will cause supervisor to restart sidecar immediately.