### PR TITLE
AMI-1761 sidecar should ABEND if a failure to register occurs.

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -19,18 +19,21 @@ fs.readFile('/etc/buildnumber', function(err, data) {
 
 	SplunkCloudDynamicConfig.get_user_data(function(err, userdata) {
 		process.env.CLOUD_STACK = process.env.CLOUD_STACK || userdata.CLOUD_STACK;
-		sidecar.initialize({
-			'cloud_stack': process.env.CLOUD_STACK,
-			'app': process.env.APP || 'sidecar',
-			'ip-address': process.env.IP_ADDRESS || os.networkInterfaces().eth0[0].address,
-			'app-port': process.env.PORT || '5000',
-			'proto': process.env.PROTO || 'http',
-			'hostname': process.env.HOSTNAME || os.hostname(),
-			'metadata': {
-				'version': process.env.VERSION || '0.0.1',
-				'build': buildNumber
-			}
-		});
+		// Timeout to prevent runaway restarts
+		setTimeout(function() {
+			sidecar.initialize({
+				'cloud_stack': process.env.CLOUD_STACK,
+				'app': process.env.APP || 'sidecar',
+				'ip-address': process.env.IP_ADDRESS || os.networkInterfaces().eth0[0].address,
+				'app-port': process.env.PORT || '5000',
+				'proto': process.env.PROTO || 'http',
+				'hostname': process.env.HOSTNAME || os.hostname(),
+				'metadata': {
+					'version': process.env.VERSION || '0.0.1',
+					'build': buildNumber
+				}
+			});
+		}, 5000);
 	});
 });
 

--- a/lib/eureka-sidecar.js
+++ b/lib/eureka-sidecar.js
@@ -135,11 +135,17 @@ module.exports = {
             }
         };
 
+        var abort = function(err) {
+            winston.error(err.message, metadata);
+            throw err;
+        };
+
         var req = this.client.post(this.options['eureka_url'] + '/' +
             this.options['eureka_version'] + '/apps/' + this.options['app'],
             register_args, function (data, response) {
                 if (response.statusCode >= 300) {
                     winston.error(data, metadata);
+                    abort(new Error('eureka server returned response code ' + response.statusCode));
                 } else {
                     this.registered = true;
                     metadata = {
@@ -150,16 +156,18 @@ module.exports = {
                     winston.info("Service is up", metadata);
                 }
             }.bind(this));
+
         var errorHandler = function(req) {
             metadata.level = "CRITICAL";
             winston.error("socket error", metadata);
             req.abort();
+            abort(new Error('error reaching eureka server'));
         };
         req.on('requestTimeout', errorHandler);
         req.on('responseTimeout', errorHandler);
         req.on('error', function(err) {
             metadata.level = "CRITICAL";
-            winston.error(err.message, metadata);
+            abort(err);
         });
     },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eureka-sidecar",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Library and optional CLI for registering with a Eureka service discovery server",
   "main": "lib/eureka-sidecar.js",
   "bin": {


### PR DESCRIPTION
nb: this ABEND only happens if eureka cannot be reached for the initial
registration.  Because it is an abnormal exit, supervisor will by default
restart the process after a short period of time and it will retry.  This
should be sufficient to solve the issue raised in AMI-1761.

AMI-2067 bump version

AMI-2067 abort after eureka error, delay on startup to spoof supervisord

This PR is a rebase and squash of #11 